### PR TITLE
database for drone server and etc

### DIFF
--- a/.drone-ci/.drone.yml
+++ b/.drone-ci/.drone.yml
@@ -16,7 +16,7 @@ steps:
 - name: fetch
   image: alpine/git
   commands:
-  - git clone https://github.com/${DRONE_REPO_OWNER}/stress-test-results.git
+  - git clone -b main https://github.com/${DRONE_REPO_OWNER}/stress-test-results.git
   - git clone -b ${DRONE_BRANCH}  https://github.com/${DRONE_REPO}.git
   - cd stress-test
   - git clone https://github.com/${DRONE_REPO_OWNER}/zkopru.git
@@ -71,7 +71,7 @@ steps:
   image: zkopru/git
   commands:
   - cd /drone/src/stress-test-results
-  - git checkout develop
+  - git checkout main
   - git checkout -b result/${DRONE_BUILD_NUMBER}
   - mv /drone/src/result.json /drone/src/stress-test-results/src/content/result_${DRONE_BUILD_NUMBER}.json
   - git add .

--- a/.drone-ci/.drone.yml
+++ b/.drone-ci/.drone.yml
@@ -72,11 +72,11 @@ steps:
   commands:
   - cd /drone/src/stress-test-results
   - git checkout develop
-  - git checkout -b test/${DRONE_BUILD_NUMBER}
+  - git checkout -b result/${DRONE_BUILD_NUMBER}
   - mv /drone/src/result.json /drone/src/stress-test-results/src/content/result_${DRONE_BUILD_NUMBER}.json
   - git add .
   - git commit -m "test result ${DRONE_BUILD_NUMBER}"
-  - git push origin test/${DRONE_BUILD_NUMBER}
+  - git push origin result/${DRONE_BUILD_NUMBER}
 
 volumes:
 - name: docker.sock

--- a/.drone-ci/README.md
+++ b/.drone-ci/README.md
@@ -22,6 +22,7 @@ You must set those variable for using the `docker-compose.yml` in `.drone-ci`.
 - DRONE_SERVER_PROTO
 - DRONE_RPC_HOST
 - DRONE_RPC_PROTO
+- POSTGRES_PASSWORD
 
 Please see links for set these variables above.
 

--- a/.drone-ci/docker-compose.yml
+++ b/.drone-ci/docker-compose.yml
@@ -17,12 +17,30 @@ services:
       - DRONE_GITHUB_CLIENT_ID
       - DRONE_GITHUB_CLIENT_SECRET
       - DRONE_USER_CREATE=username:admin,machine:false,admin:true
+      - DRONE_DATABASE_DRIVER=postgres
+      - DRONE_DATABASE_DATASOURCE=postgres://drone:${POSTGRES_PASSWORD}@drone-database:5432/drone?sslmode=disable
       - DRONE_RPC_SECRET
       - DRONE_SERVER_HOST
       - DRONE_SERVER_PROTO
       - DRONE_LOGS_DEBUG=true
       - DRONE_LOGS_TRACE=true
       - DRONE_LOGS_PRETTY=true
+    depends_on:
+      - drone-database
+
+  drone-database:
+    image: postgres:alpine
+    container_name: drone-database
+    networks:
+      - drone-network
+    restart: always
+    volumes:
+      - drone_data/:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=drone
+      - POSTGRES_USER=drone
+      - POSTGRES_PASSWORD
+
   drone-runner:
     image: drone/drone-runner-docker
     container_name: drone-runner
@@ -43,6 +61,10 @@ services:
       - DRONE_RUNNER_NETWORKS=drone_network
       - DRONE_DEBUG=true
       - DRONE_TRACE=true
+
+volumes:
+  drone-data:
+    external: true
 
 networks:
   drone_network:


### PR DESCRIPTION
- previously, the drone server used the default database, SQLite. which is not recommendation, and a little bit slow with a bunch of logs.
- following drone ci doc, the drone server will be running with Postgresql.
- set target branch as `result/*` instead of `test/`