### PR TITLE
git data from environment variables

### DIFF
--- a/.drone-ci/.drone.yml
+++ b/.drone-ci/.drone.yml
@@ -47,6 +47,10 @@ steps:
   - name: docker.sock
     path: /var/run/docker.sock
   environment:
+    ZKOPRU_BRANCH: ${TRIGGER_BRANCH}
+    ZKOPRU_COMMIT_HASH: ${TRIGGER_HASH}
+    TEST_BRANCH: ${DRONE_BRANCH}
+    TEST_COMMIT_HASH: ${DRONE_COMMIT}
     walletNum:
       from_secret: wallet-number
   detach: true
@@ -77,6 +81,16 @@ steps:
   - git add .
   - git commit -m "test result ${DRONE_BUILD_NUMBER}"
   - git push origin result/${DRONE_BUILD_NUMBER}
+
+- name: update-submodule
+  pull: never
+  image: zkopru/git
+  commands:
+  - cd /drone/src/stress-test
+  - git checkout main
+  - git add .
+  - git commit -m "zkopru ${TRIGGER_BRANCH}@${TRIGGER_HASH}" || true
+  - git push origin main || true
 
 volumes:
 - name: docker.sock

--- a/.drone-ci/.drone.yml
+++ b/.drone-ci/.drone.yml
@@ -65,6 +65,7 @@ steps:
     path: /var/run/docker.sock
   commands:
   - sleep 30
+  - docker rm -f watchTower || true
   - docker run --name watchTower -v /var/run/docker.sock:/var/run/docker.sock --network stress-test zkopru_node node /generator/scripts/test-watcher.js
   - docker cp watchTower:/generator/result.json ./
   - docker rm watchTower

--- a/compose/docker-compose.localtest-geth.dev.yml
+++ b/compose/docker-compose.localtest-geth.dev.yml
@@ -48,6 +48,11 @@ services:
       - '../dist/src:/generator/dist'
     labels:
       kompose.service.expose: organizer
+    environment:
+      - ZKOPRU_BRANCH=${ZKOPRU_BRANCH}
+      - ZKOPRU_COMMIT_HASH=${ZKOPRU_COMMIT_HASH}
+      - TEST_BRANCH=${TEST_BRANCH}
+      - TEST_COMMIT_HASH=${TEST_COMMIT_HASH}
     command: bash -c "node /generator/dist/organizer/index.js"
   wallet:
     image: zkopru_node:latest

--- a/compose/docker-compose.localtest-geth.yml
+++ b/compose/docker-compose.localtest-geth.yml
@@ -43,6 +43,11 @@ services:
       - 'coordinator'
     labels:
       kompose.service.expose: organizer
+    environment:
+      - ZKOPRU_BRANCH=${ZKOPRU_BRANCH}
+      - ZKOPRU_COMMIT_HASH=${ZKOPRU_COMMIT_HASH}
+      - TEST_BRANCH=${TEST_BRANCH}
+      - TEST_COMMIT_HASH=${TEST_COMMIT_HASH}
     command: bash -c "node /generator/dist/organizer/index.js"
   wallet:
     image: zkopru_node

--- a/dockerfiles/Generator.dockerfile
+++ b/dockerfiles/Generator.dockerfile
@@ -26,9 +26,6 @@ WORKDIR /generator
 # Copy SNARK keys
 COPY zkopru/packages/circuits/keys /proj/keys
 
-# COPY git data for generating metadata
-COPY .git /generator/metadata/stress-test/
-
 # Copy package.json
 COPY zkopru/.package-dev.json /generator/zkopru/package.json
 COPY zkopru/lerna.json /generator/zkopru/lerna.json

--- a/src/organizer/organizer.ts
+++ b/src/organizer/organizer.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import fs from 'fs'
 import si from 'systeminformation'
 import { logger, sleep } from '@zkopru/utils'
 import { OrganizerConfig, OrganizerContext } from './context'

--- a/src/organizer/organizer.ts
+++ b/src/organizer/organizer.ts
@@ -33,28 +33,16 @@ export class Organizer {
     const memInfo = await si.mem()
 
     // git branch and commit heash
-    const targetMeta = ['stress-test', 'zkopru']
-    let gitData = {}
-
-    targetMeta.forEach(repo => {
-      let branch: string
-      let commit: string
-      // headFile path is fixed dockerfile
-      const headFile = `metadata/${repo}/HEAD`
-
-      if (fs.existsSync(headFile)) {
-        const head = fs.readFileSync(headFile)
-        const headPath = head.toString().split(" ")[1].trim()
-        const headHash = fs.readFileSync(`metadata/${repo}/${headPath}`)
-
-        branch = headPath.split("/").slice(2,).join("/"),
-          commit = headHash.toString().trim()
-      } else {
-        branch = "Not Found",
-          commit = "0000000000000000000000000000000000000000"
+    const gitData = {
+      "stress-test": {
+        branch: process.env.TEST_BRANCH ?? "Not found",
+        commit: process.env.TEST_COMMIT_HASH ?? "0000000000000000000000000000000000000000"
+      },
+      zkopru: {
+        branch: process.env.ZKOPRU_BRANCH ?? "Not found",
+        commit: process.env.ZKOPRU_COMMIT_HASH ?? "0000000000000000000000000000000000000000"
       }
-      gitData[repo] = { branch, commit }
-    })
+    }
 
     const { targetTPS } = this.context.organizerQueue.currentRate()
 


### PR DESCRIPTION
Currently,  there is a process that copies git directory into images for getting the git info(branch, commit hash..). 

this is space waste for the image for testing. so, we are going to use the outside variable which is delivered CI server.